### PR TITLE
Optimize libsepol avtab to improve assertion check performance

### DIFF
--- a/libsepol/include/sepol/policydb/avtab.h
+++ b/libsepol/include/sepol/policydb/avtab.h
@@ -81,7 +81,7 @@ typedef struct avtab {
 	avtab_ptr_t *htable;
 	uint32_t nel;		/* number of elements */
 	uint32_t nslot;         /* number of hash slots */
-	uint16_t mask;          /* mask to compute hash func */
+	uint32_t mask;          /* mask to compute hash func */
 } avtab_t;
 
 extern int avtab_init(avtab_t *);
@@ -117,10 +117,11 @@ extern avtab_ptr_t avtab_search_node(avtab_t * h, avtab_key_t * key);
 
 extern avtab_ptr_t avtab_search_node_next(avtab_ptr_t node, int specified);
 
-#define MAX_AVTAB_HASH_BITS 13
+#define MAX_AVTAB_HASH_BITS 20
 #define MAX_AVTAB_HASH_BUCKETS (1 << MAX_AVTAB_HASH_BITS)
 #define MAX_AVTAB_HASH_MASK (MAX_AVTAB_HASH_BUCKETS-1)
-#define MAX_AVTAB_SIZE MAX_AVTAB_HASH_BUCKETS
+/* avtab_alloc uses one bucket per 2-4 elements, so adjust to get maximum buckets */
+#define MAX_AVTAB_SIZE (MAX_AVTAB_HASH_BUCKETS << 1)
 
 #endif				/* _AVTAB_H_ */
 

--- a/libsepol/src/Makefile
+++ b/libsepol/src/Makefile
@@ -15,7 +15,7 @@ LIBPC=libsepol.pc
 LIBSO=$(TARGET).$(LIBVERSION)
 OBJS= $(patsubst %.c,%.o,$(wildcard *.c))
 LOBJS= $(patsubst %.c,%.lo,$(wildcard *.c))
-CFLAGS ?= -Werror -Wall -W -Wundef -Wshadow -Wmissing-noreturn -Wmissing-format-attribute
+CFLAGS ?= -Werror -Wall -W -Wundef -Wshadow -Wmissing-noreturn -Wmissing-format-attribute -O2
 override CFLAGS += -I. -I../include -D_GNU_SOURCE
 
 all: $(LIBA) $(LIBSO) $(LIBPC)

--- a/libsepol/src/avtab.c
+++ b/libsepol/src/avtab.c
@@ -333,7 +333,7 @@ int avtab_init(avtab_t * h)
 
 int avtab_alloc(avtab_t *h, uint32_t nrules)
 {
-	uint16_t mask = 0;
+	uint32_t mask = 0;
 	uint32_t shift = 0;
 	uint32_t work = nrules;
 	uint32_t nslot = 0;
@@ -348,8 +348,8 @@ int avtab_alloc(avtab_t *h, uint32_t nrules)
 	if (shift > 2)
 		shift = shift - 2;
 	nslot = 1 << shift;
-	if (nslot > MAX_AVTAB_SIZE)
-		nslot = MAX_AVTAB_SIZE;
+	if (nslot > MAX_AVTAB_HASH_BUCKETS)
+		nslot = MAX_AVTAB_HASH_BUCKETS;
 	mask = nslot - 1;
 
 	h->htable = calloc(nslot, sizeof(avtab_ptr_t));

--- a/libsepol/src/services.c
+++ b/libsepol/src/services.c
@@ -417,6 +417,12 @@ static int constraint_expr_eval_reason(context_struct_t *scontext,
 	int rc = 0, x;
 	char *class_buf = NULL;
 
+	/*
+	 * The array of expression answer buffer pointers and counter.
+	 */
+	char **answer_list = NULL;
+	int answer_counter = 0;
+
 	class_buf = get_class_info(tclass, constraint, xcontext);
 	if (!class_buf) {
 		ERR(NULL, "failed to allocate class buffer");
@@ -686,13 +692,9 @@ mls_ops:
 	expr_counter = 0;
 
 	/*
-	 * The array of expression answer buffer pointers and counter.
 	 * Generate the same number of answer buffer entries as expression
 	 * buffers (as there will never be more).
 	 */
-	char **answer_list;
-	int answer_counter = 0;
-
 	answer_list = malloc(expr_count * sizeof(*answer_list));
 	if (!answer_list) {
 		ERR(NULL, "failed to allocate answer stack");


### PR DESCRIPTION
These changes reduce the time to run `semanage -r` with `expand-check=1` from over an hour to 2m30s for my system using the Fedora targeted policy. There should be an equivalent improvement for `semodule_expand`.

The hash table does use more memory (4-8MB per full-size instance), but this is a trivial amount compared to the cost of loading the policy. I never observed more than 3 instances of this hash allocated together.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1177994