### PR TITLE
Simplication of sepolicy-manpage web functionality.

### DIFF
--- a/policycoreutils/sepolicy/sepolicy/__init__.py
+++ b/policycoreutils/sepolicy/sepolicy/__init__.py
@@ -934,28 +934,14 @@ def boolean_desc(boolean):
            return "Allow %s to %s" % (desc[0], " ".join(desc[1:]))
 
 def get_os_version():
-    os_version = ""
-    pkg_name = "selinux-policy"
+    system_release = ""
     try:
-        import subprocess
-        output = subprocess.check_output("rpm -q '%s'" % pkg_name,
-                                         stderr=subprocess.STDOUT,
-                                         shell=True)
-        try:
-            os_version = str(output).split(".")[-2]
-            if os_version[0:2] == "fc":
-                os_version = "Fedora"+os_version[2:]
-            elif os_version[0:2] == "el":
-                os_version = "RHEL"+os_version[2:]
-            else:
-                os_version = "Misc"
-        except IndexError:
-            os_version = "Misc"
+        with open('/etc/system-release') as f:
+            system_release = f.readline()
+    except IOError:
+        system_release = "Misc"
 
-    except subprocess.CalledProcessError:
-        os_version = "Misc"
-
-    return os_version
+    return system_release
 
 def reinit():
     global all_attributes

--- a/policycoreutils/sepolicy/sepolicy/__init__.py
+++ b/policycoreutils/sepolicy/sepolicy/__init__.py
@@ -937,7 +937,7 @@ def get_os_version():
     system_release = ""
     try:
         with open('/etc/system-release') as f:
-            system_release = f.readline()
+            system_release = f.readline().rstrip()
     except IOError:
         system_release = "Misc"
 

--- a/policycoreutils/sepolicy/sepolicy/manpage.py
+++ b/policycoreutils/sepolicy/sepolicy/manpage.py
@@ -214,7 +214,7 @@ class HTMLManPages:
 <html>
 <head>
         <link rel=stylesheet type="text/css" href="style.css" title="style">
-        <title>SELinux man pages online</title>
+        <title>SELinux man pages</title>
 </head>
 <body>
 <h1>SELinux man pages for %s</h1>

--- a/policycoreutils/sepolicy/sepolicy/manpage.py
+++ b/policycoreutils/sepolicy/sepolicy/manpage.py
@@ -143,9 +143,6 @@ def prettyprint(f,trim):
 manpage_domains = []
 manpage_roles = []
 
-fedora_releases = ["Fedora17","Fedora18","Fedora19","Fedora20","Fedora21","Fedora22"]
-rhel_releases = ["RHEL6","RHEL7"]
-
 def get_alphabet_manpages(manpage_list):
         alphabet_manpages = dict.fromkeys(string.ascii_letters, [])
         for i in string.ascii_letters:
@@ -181,9 +178,9 @@ class HTMLManPages:
                 self.manpage_domains = get_alphabet_manpages(manpage_domains)
                 self.os_version = os_version
                 self.old_path = path + "/"
-                self.new_path = self.old_path + self.os_version+"/"
+                self.new_path = self.old_path
 
-                if (self.os_version in fedora_releases) or (self.os_version in rhel_releases) or (self.os_version == "Misc"):
+                if self.os_version:
 
                         self.__gen_html_manpages()
                 else:
@@ -193,7 +190,6 @@ class HTMLManPages:
         def __gen_html_manpages(self):
                 self._write_html_manpage()
                 self._gen_index()
-                self._gen_body()
                 self._gen_css()
 
         def _write_html_manpage(self):
@@ -212,67 +208,21 @@ class HTMLManPages:
 
 
         def _gen_index(self):
-                index = self.old_path+"index.html"
-                fd = open(index,'w')
-                fd.write("""
-<html>
-<head>
-    <link rel=stylesheet type="text/css" href="style.css" title="style">
-    <title>SELinux man pages online</title>
-</head>
-<body>
-<h1>SELinux man pages</h1>
-<br></br>
-Fedora or Red Hat Enterprise Linux Man Pages.</h2>
-<br></br>
-<hr>
-<h3>Fedora</h3>
-<table><tr>
-<td valign="middle">
-</td>
-</tr></table>
-<pre>
-""")
-                for f in fedora_releases:
-                        fd.write("""
-<a href=%s/%s.html>%s</a> - SELinux man pages for %s """  % (f,f,f,f))
-
-                fd.write("""
-</pre>
-<hr>
-<h3>RHEL</h3>
-<table><tr>
-<td valign="middle">
-</td>
-</tr></table>
-<pre>
-""")
-                for r in rhel_releases:
-                        fd.write("""
-<a href=%s/%s.html>%s</a> - SELinux man pages for %s """ % (r,r,r,r))
-
-                fd.write("""
-</pre>
-        """)
-                fd.close()
-                print(("%s has been created") % index)
-
-        def _gen_body(self):
-                html = self.new_path+self.os_version+".html"
+                html = self.new_path+"index.html"
                 fd = open(html,'w')
                 fd.write("""
 <html>
 <head>
-        <link rel=stylesheet type="text/css" href="../style.css" title="style">
-        <title>Linux man-pages online for Fedora</title>
+        <link rel=stylesheet type="text/css" href="style.css" title="style">
+        <title>SELinux man pages online</title>
 </head>
 <body>
-<h1>SELinux man pages for Fedora18</h1>
+<h1>SELinux man pages for %s</h1>
 <hr>
 <table><tr>
 <td valign="middle">
 <h3>SELinux roles</h3>
-""")
+""" % self.os_version)
                 for letter in self.manpage_roles:
                         if len(self.manpage_roles[letter]):
                                 fd.write("""


### PR DESCRIPTION
Previously, we hardcoded system releases which caused that sepolicy-manpage with "-w" option had been failing with a new release. With this fixes, there is no need for hardcoding of system releases and if a new OS release is done, sepolicy-manpage will work as expected.

This change also will require change in selinux-policy.spec related to man pages handling and it will need to require the policycoreutils pkg with this fix.

