### PR TITLE
policycoreutils: improve compatibility with Python 3

### DIFF
--- a/policycoreutils/sepolicy/search.c
+++ b/policycoreutils/sepolicy/search.c
@@ -1000,8 +1000,19 @@ static int Dict_ContainsInt(PyObject *dict, const char *key){
 
 static const char *Dict_ContainsString(PyObject *dict, const char *key){
     PyObject *item = PyDict_GetItemString(dict, key);
-    if (item)
-	    return PyBytes_AsString(item);
+    if (item) {
+        if (PyUnicode_Check(item)) {
+            char *str = NULL;
+            PyObject *item_utf8 = PyUnicode_AsUTF8String(item);
+            if (item_utf8) {
+                str = strdup(PyBytes_AsString(item_utf8));
+            }
+            Py_XDECREF(item_utf8);
+            return str;
+        } else {
+            return PyBytes_AsString(item);
+        }
+    }
     return NULL;
 }
 

--- a/policycoreutils/sepolicy/selinux_server.py
+++ b/policycoreutils/sepolicy/selinux_server.py
@@ -3,7 +3,7 @@
 import dbus
 import dbus.service
 import dbus.mainloop.glib
-import gobject
+from gi.repository import GObject, GLib
 import slip.dbus.service
 from slip.dbus import polkit
 import os
@@ -127,7 +127,7 @@ class selinux_server(slip.dbus.service.Object):
         raise ValueError("%s does not exist" % path)
         
 if __name__ == "__main__":
-        mainloop = gobject.MainLoop()
+        mainloop = GLib.MainLoop()
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         system_bus = dbus.SystemBus()
         name = dbus.service.BusName("org.selinux", system_bus)

--- a/policycoreutils/sepolicy/sepolicy.py
+++ b/policycoreutils/sepolicy/sepolicy.py
@@ -25,6 +25,7 @@ import os, sys
 import selinux
 import sepolicy
 from sepolicy import get_os_version, get_conditionals, get_conditionals_format_text
+from sepolgen import util
 import argparse
 import gettext
 PROGNAME="policycoreutils"
@@ -398,6 +399,8 @@ def booleans(args):
     from sepolicy import boolean_desc
     if args.all:
         rc, args.booleans = selinux.security_get_boolean_names()
+        if util.PY3:
+            args.booleans = [util.decode_input(x) for x in args.booleans]
     args.booleans.sort()
 
     for b in args.booleans:

--- a/policycoreutils/sepolicy/sepolicy.py
+++ b/policycoreutils/sepolicy/sepolicy.py
@@ -220,7 +220,7 @@ def numcmp(val1,val2):
         if v1 < v2:
             return -1
     except:
-        return cmp(val1,val2)
+        return (val1 > val2) - (val1 < val2)
 
 def _print_net(src, protocol, perm):
     import sepolicy.network
@@ -239,7 +239,7 @@ def _print_net(src, protocol, perm):
                     port_strings.append("%s (%s) %s" % (", ".join(recs), t, boolean_text))
                 else:
                     port_strings.append("%s (%s)" % (", ".join(recs), t))
-        port_strings.sort(numcmp)
+        port_strings.sort(key=util.cmp_to_key(numcmp))
         for p in port_strings:
                 print("\t" + p)
 

--- a/policycoreutils/sepolicy/sepolicy/__init__.py
+++ b/policycoreutils/sepolicy/sepolicy/__init__.py
@@ -595,7 +595,7 @@ def get_all_domains():
         return all_domains
 
 def mls_cmp(x,y):
-    return cmp(int(x[1:]), int(y[1:]))
+    return (int(x[1:]) > int(y[1:])) - (int(x[1:]) < int(y[1:]))
 
 mls_range = None
 def get_mls_range():
@@ -604,7 +604,7 @@ def get_mls_range():
                 return mls_rangeroles
         range_dict = info(SENS)
         keys = range_dict.keys()
-        keys.sort(cmp=mls_cmp)
+        keys.sort(key=util.cmp_to_key(mls_cmp))
         mls_range = "%s-%s" % (keys[0], range_dict[keys[-1]])
         return mls_range
 

--- a/policycoreutils/sepolicy/sepolicy/__init__.py
+++ b/policycoreutils/sepolicy/sepolicy/__init__.py
@@ -9,6 +9,7 @@ PROGNAME="policycoreutils"
 import gettext
 import sepolgen.defaults as defaults
 import sepolgen.interfaces as interfaces
+from sepolgen import util
 import sys
 import subprocess
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
@@ -872,6 +873,8 @@ def get_all_booleans():
     global booleans
     if not booleans:
         booleans = selinux.security_get_boolean_names()[1]
+        if util.PY3:
+            booleans = [util.decode_input(x) for x in booleans]
     return booleans
 
 booleans_dict = None

--- a/policycoreutils/sepolicy/sepolicy/generate.py
+++ b/policycoreutils/sepolicy/sepolicy/generate.py
@@ -44,6 +44,7 @@ from .templates import spec
 from .templates import user
 import sepolgen.interfaces as interfaces
 import sepolgen.defaults as defaults
+from sepolgen import util
 
 ##
 ## I18N
@@ -70,6 +71,11 @@ def get_rpm_nvr_from_header(hdr):
     name    = hdr['name']
     version = hdr['version']
     release = hdr['release']
+    if util.PY3:
+        name = util.decode_input(name)
+        version = util.decode_input(version)
+        release = util.decode_input(release)
+
     release_version = version+"-"+release.split(".")[0]
     os_version = release.split(".")[1]
 

--- a/policycoreutils/sepolicy/sepolicy/manpage.py
+++ b/policycoreutils/sepolicy/sepolicy/manpage.py
@@ -163,7 +163,7 @@ def convert_manpage_to_html(html_manpage,manpage):
         except subprocess.CalledProcessError as e:
                 sys.stderr.write(e.output)
                 return
-        fd = open(html_manpage,'w')
+        fd = open(html_manpage,'wb')
         fd.write(man_page)
         fd.close()
         print(html_manpage)

--- a/sepolgen/src/sepolgen/audit.py
+++ b/sepolgen/src/sepolgen/audit.py
@@ -546,14 +546,11 @@ class AuditParser:
         return path
 
     def __store_base_types(self):
-        # FIXME: this is a temporary workaround until sepolicy is ported to python 3
-        # import sepolicy
-        # self.base_types = sepolicy.get_types_from_attribute("base_file_type")
-        self.base_types = []
+        import sepolicy
+        self.base_types = sepolicy.get_types_from_attribute("base_file_type")
 
     def __get_base_type(self, tcontext, scontext):
-        # FIXME: uncomment the following code when sepolicy is ported to python 3
-        # import sepolicy
+        import sepolicy
         # Prevent unnecessary searching
         if (self.old_scontext == scontext and
             self.old_tcontext == tcontext):
@@ -562,10 +559,9 @@ class AuditParser:
         self.old_tcontext = tcontext
         for btype in self.base_types:
             if btype == tcontext:
-                # FIXME: uncomment the following code when sepolicy is ported to python 3
-                # for writable in sepolicy.get_writable_files(scontext):
-                #     if writable.endswith(tcontext) and writable.startswith(scontext.rstrip("_t")):
-                #         return writable
+                for writable in sepolicy.get_writable_files(scontext):
+                    if writable.endswith(tcontext) and writable.startswith(scontext.rstrip("_t")):
+                        return writable
                 return 0
 
     def to_access(self, avc_filter=None, only_denials=True):


### PR DESCRIPTION
This PR should fix [rhbz#1247039].

```
# sepolicy manpage -a
    Traceback (most recent call last):
      File "/usr/bin/sepolicy", line 644, in <module>
        args.func(args)
      File "/usr/bin/sepolicy", line 320, in manpage
        m = ManPage(domain, path, args.root,args.source_files, args.web)
      File "/usr/lib64/python3.4/site-packages/sepolicy/manpage.py", line 389, in __init__
        self._gen_bools()
      File "/usr/lib64/python3.4/site-packages/sepolicy/manpage.py", line 417, in _gen_bools
        domainbools, bools = get_bools(t)
      File "/usr/lib64/python3.4/site-packages/sepolicy/__init__.py", line 854, in get_bools
        for i in [x['boolean'] for x in [x for x in search([ALLOW],{'source' : setype}) if 'boolean' in x]]:
      File "/usr/lib64/python3.4/site-packages/sepolicy/__init__.py", line 854, in <listcomp>
        for i in [x['boolean'] for x in [x for x in search([ALLOW],{'source' : setype}) if 'boolean' in x]]:
    TypeError: expected bytes, str found

```

[rhbz#1247039]: https://bugzilla.redhat.com/show_bug.cgi?id=1247039