### PR TITLE
Fix rhbz#1247575

### DIFF
--- a/sepolgen/src/sepolgen/audit.py
+++ b/sepolgen/src/sepolgen/audit.py
@@ -527,9 +527,6 @@ class AuditParser:
                                              stderr=subprocess.STDOUT,
                                              shell=True,
                                              universal_newlines=True)
-            if util.PY3:
-                output = util.decode_input(output)
-
             try:
                 ino = int(inode)
             except ValueError:


### PR DESCRIPTION
This is an attempt to fix [rhbz#1247575].

The "output" is already decoded, thanks to "universal_newlines=True".

fixes:
 # audit2allow -i avc
Traceback (most recent call last):
  File "/usr/bin/audit2allow", line 360, in <module>
    app.main()
  File "/usr/bin/audit2allow", line 347, in main
    self.__process_input()
  File "/usr/bin/audit2allow", line 175, in __process_input
    self.__avs = self.__parser.to_access()
  File "/usr/lib64/python3.4/site-packages/sepolgen/audit.py", line 596, in to_access
    avc.path = self.__restore_path(avc.name, avc.ino)
  File "/usr/lib64/python3.4/site-packages/sepolgen/audit.py", line 531, in __restore_path
    output = util.decode_input(output)
  File "/usr/lib64/python3.4/site-packages/sepolgen/util.py", line 112, in decode_input
    decoded_text = text.decode(encoding)
AttributeError: 'str' object has no attribute 'decode'

This reverts commit 7e8a44d1a96de5ab945b10741af3edc2250ecb17.

[rhbz#1247575]: https://bugzilla.redhat.com/show_bug.cgi?id=1247575