### PR TITLE
policycoreutils/sandbox: Fix sandbox to propagate specified MCS/MLS Security Level.

### DIFF
--- a/policycoreutils/sandbox/sandbox
+++ b/policycoreutils/sandbox/sandbox
@@ -406,9 +406,6 @@ sandbox [-h] [-l level ] [-[X|M] [-H homedir] [-T tempdir]] [-I includefile ] [-
            self.__execcon = "%s:%s:%s:%s" % (con[0], con[1], self.setype, level)
            self.__filecon = "%s:object_r:sandbox_file_t:%s" % (con[0], level)
     def __setup_dir(self):
-           if self.__options.level or self.__options.session:
-                  return
-
            if self.__options.homedir:
                   selinux.chcon(self.__options.homedir, self.__filecon, recursive=True)
                   self.__homedir = self.__options.homedir


### PR DESCRIPTION
If "level" option is used to start sandbox commands, this level is not propagated
to specified  homedir and tmpdir directories. See rhbz #1279006.