### PR TITLE
policycoreutis/gui: test if correct iterator was acquired

### DIFF
--- a/policycoreutils/gui/semanagePage.py
+++ b/policycoreutils/gui/semanagePage.py
@@ -126,7 +126,7 @@ class semanagePage:
 
     def deleteDialog(self):
         store, it = self.view.get_selection().get_selected()
-        if self.verify(_("Are you sure you want to delete %s '%s'?" % (self.description, store.get_value(it, 0))), _("Delete %s" % self.description)) == gtk.RESPONSE_YES:
+        if (it is not None) and (self.verify(_("Are you sure you want to delete %s '%s'?" % (self.description, store.get_value(it, 0))), _("Delete %s" % self.description)) == gtk.RESPONSE_YES):
             self.delete()
 
     def use_menus(self):


### PR DESCRIPTION
TreeView.get_selection().get_selected() can return "None" if no item is selected
(the list can be empty). Add test.

Fixes:
  https://bugzilla.redhat.com/show_bug.cgi?id=1344842
