### PR TITLE
policycoreutils/gui: fix fcontextPage editing features

### DIFF
--- a/policycoreutils/gui/fcontextPage.py
+++ b/policycoreutils/gui/fcontextPage.py
@@ -96,13 +96,6 @@ class fcontextPage(semanagePage):
         self.load()
         self.fcontextEntry = xml.get_widget("fcontextEntry")
         self.fcontextFileTypeCombo = xml.get_widget("fcontextFileTypeCombo")
-        liststore = self.fcontextFileTypeCombo.get_model()
-        for k in seobject.file_types:
-            if len(k) > 0 and  k[0] != '-':
-                it=liststore.append()
-                liststore.set_value(it, 0, k)
-        it = liststore.get_iter_first()
-        self.fcontextFileTypeCombo.set_active_iter(it)
         self.fcontextTypeEntry = xml.get_widget("fcontextTypeEntry")
         self.fcontextMLSEntry = xml.get_widget("fcontextMLSEntry")
 
@@ -176,7 +169,7 @@ class fcontextPage(semanagePage):
         ftype=store.get_value(it, FTYPE_COL)
         self.wait()
         try:
-            subprocess.check_output("semanage fcontext -d -f '%s' '%s'" % (ftype, fspec),
+            subprocess.check_output("semanage fcontext -d -f '%s' '%s'" % (seobject.file_type_str_to_option[ftype], fspec),
                                     stderr=subprocess.STDOUT,
                                     shell=True)
             store.remove(it)
@@ -186,15 +179,15 @@ class fcontextPage(semanagePage):
         self.ready()
 
     def add(self):
-        ftype=["", "--", "-d", "-c", "-b", "-s", "-l", "-p" ]
         fspec=self.fcontextEntry.get_text().strip()
         setype=self.fcontextTypeEntry.get_text().strip()
         mls=self.fcontextMLSEntry.get_text().strip()
         list_model=self.fcontextFileTypeCombo.get_model()
-        active = self.fcontextFileTypeCombo.get_active()
+        it = self.fcontextFileTypeCombo.get_active_iter()
+        ftype=list_model.get_value(it,0)
         self.wait()
         try:
-            subprocess.check_output("semanage fcontext -a -t %s -r %s -f '%s' '%s'" % (setype, mls, ftype[active], fspec),
+            subprocess.check_output("semanage fcontext -a -t %s -r %s -f '%s' '%s'" % (setype, mls, seobject.file_type_str_to_option[ftype], fspec),
                                     stderr=subprocess.STDOUT,
                                     shell=True)
             self.ready()
@@ -216,7 +209,7 @@ class fcontextPage(semanagePage):
         ftype=list_model.get_value(it,0)
         self.wait()
         try:
-            subprocess.check_output("semanage fcontext -m -t %s -r %s -f '%s' '%s'" % (setype, mls, ftype, fspec),
+            subprocess.check_output("semanage fcontext -m -t %s -r %s -f '%s' '%s'" % (setype, mls, seobject.file_type_str_to_option[ftype], fspec),
                                     stderr=subprocess.STDOUT,
                                     shell=True)
             self.ready()

--- a/policycoreutils/gui/semanagePage.py
+++ b/policycoreutils/gui/semanagePage.py
@@ -163,7 +163,7 @@ class semanagePage:
 
         while self.dialog.run() == gtk.RESPONSE_OK:
             try:
-                if not self.add():
+                if self.add() is False:
                     continue
                 break;
             except ValueError as e:
@@ -176,7 +176,7 @@ class semanagePage:
         self.dialog.set_position(gtk.WIN_POS_MOUSE)
         while self.dialog.run() == gtk.RESPONSE_OK:
             try:
-                if not self.modify():
+                if self.modify() is False:
                     continue
                 break;
             except ValueError as e:

--- a/policycoreutils/gui/system-config-selinux.glade
+++ b/policycoreutils/gui/system-config-selinux.glade
@@ -729,7 +729,7 @@ regular file
 directory
 character device
 block device
-socket
+socket file
 symbolic link
 named pipe
 </property>


### PR DESCRIPTION
"ftype" dropdown was filled from 2 sources (system-config-selinux.glade
and fcontextPage - from seobject module) which resulted in duplicate
and invalid options. When given to "semanage fcontext -f", ftype has to be
converted to 1 letter argument mode.
"Edit" and "add" dialogues weren't closed after successful transaction
("add" and "edit" methods return "None" if successful).

Signed-off-by: vmojzis vmojzis@redhat.com
