### PR TITLE
libselinux: Fix pointer handling in realpath_not_final

### DIFF
--- a/libselinux/src/matchpathcon.c
+++ b/libselinux/src/matchpathcon.c
@@ -362,12 +362,6 @@ int realpath_not_final(const char *name, char *resolved_path)
 		goto out;
 	}
 
-	/* strip leading // */
-	while (tmp_path[len] && tmp_path[len] == '/' &&
-	       tmp_path[len+1] && tmp_path[len+1] == '/') {
-		tmp_path++;
-		len++;
-	}
 	last_component = strrchr(tmp_path, '/');
 
 	if (last_component == tmp_path) {


### PR DESCRIPTION
tmp_path is the only reference to memory allocated by "strdup" and
needs to be pointing at the beginning of the allocated block before
free() is called.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1376598
