### PR TITLE
policycoreutils/sepolicy/gui: fix current selinux state radiobutton

### DIFF
--- a/policycoreutils/sepolicy/sepolicy/gui.py
+++ b/policycoreutils/sepolicy/sepolicy/gui.py
@@ -2556,9 +2556,10 @@ class SELinuxGui():
     def set_enforce_text(self, value):
         if value:
             self.status_bar.push(self.context_id, _("System Status: Enforcing"))
+            self.current_status_enforcing.set_active(True)
         else:
             self.status_bar.push(self.context_id, _("System Status: Permissive"))
-        self.current_status_permissive.set_active(True)
+            self.current_status_permissive.set_active(True)
 
     def set_enforce(self, button):
         if not self.finish_init:


### PR DESCRIPTION
Radiobutton was always set to "Permissive" and couldn't be switched.
Update radiobutton together with status text in bottom left corner.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1319242

Signed-off-by: vmojzis <vmojzis@redhat.com>