### PR TITLE
sepolicy-generate: Handle more reserved port types

### DIFF
--- a/python/sepolicy/sepolicy/generate.py
+++ b/python/sepolicy/sepolicy/generate.py
@@ -103,7 +103,9 @@ def get_all_ports():
     for p in sepolicy.info(sepolicy.PORT):
         if p['type'] == "reserved_port_t" or \
                 p['type'] == "port_t" or \
-                p['type'] == "hi_reserved_port_t":
+                p['type'] == "hi_reserved_port_t" or \
+                p['type'] == "ephemeral_port_t" or \
+                p['type'] == "unreserved_port_t":
             continue
         dict[(p['low'], p['high'], p['protocol'])] = (p['type'], p.get('range'))
     return dict


### PR DESCRIPTION
Currently only reserved_port_t, port_t and hi_reserved_port_t are
handled as special when making a ports-dictionary.  However, as fas as
corenetwork.te.in of serefpolicy, unreserved_port_t and
ephemeral_port_t should be handled in the same way, too.

(Details) I found the need of this change when I was using
selinux-polgengui.  Though tcp port 12345, which my application may
use, was given to the gui, selinux-polgengui generates expected te
file and sh file which didn't utilize the tcp port.

selinux-polgengui checks whether a port given via gui is already typed
or not.

If it is already typed, selinux-polgengui generates a te file having
rules to allow the application to use the port. (A)

If not, it seems for me that selinux-polgengui is designed to generate
a te file having rules to allow the application to own(?) the port;
and a sh file having a command line to assign the application own type
to the port. (B)

As we can see the output of `semanage port -l' some of ports for
specified purpose have types already.  The important point is that the
rest of ports also have types already:

    hi_reserved_port_t tcp 512-1023
    hi_reserved_port_t udp 512-1023
    unreserved_port_t tcp 1024-32767, 61001-65535
    unreserved_port_t udp 1024-32767, 61001-65535
    ephemeral_port_t tcp 32768-61000
    ephemeral_port_t udp 32768-61000

As my patch shows, the original selinux-polgengui ignored
hi_reserved_port_t; though hi_reserved_port_t is assigned,
selinux-polgengui considered ports 512-1023 are not used. As the
result selinux-polgengui generates file sets of (B).

For the purpose of selinux-polgengui, I think unreserved_port_t and
ephemeral_port_t are treated as the same as hi_reserved_port_t.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>