### PR TITLE
python/semanage/seobject.py: Fix undefined store check

### DIFF
--- a/python/semanage/seobject.py
+++ b/python/semanage/seobject.py
@@ -2651,7 +2651,7 @@ class booleanRecords(semanageRecords):
             self.current_booleans = []
             ptype = None
 
-        if self.store is None or self.store == ptype:
+        if self.store is "" or self.store == ptype:
             self.modify_local = True
         else:
             self.modify_local = False


### PR DESCRIPTION
self.store is always a string (actual store name or "")
because of semanageRecords.__init__
Fix check for not defined store.

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>