### PR TITLE
libsemanage: do not change file mode of seusers and users_extra

### DIFF
--- a/dbus/org.selinux.conf
+++ b/dbus/org.selinux.conf
@@ -12,12 +12,8 @@
 
   <!-- Allow anyone to invoke methods on the interfaces,
        authorization is performed by PolicyKit -->
-  <policy at_console="true">
-    <allow send_destination="org.selinux"/>
-  </policy>
   <policy context="default">
-    <allow send_destination="org.selinux"
-	   send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.selinux"/>
   </policy>
 
 </busconfig>

--- a/dbus/org.selinux.policy
+++ b/dbus/org.selinux.policy
@@ -70,9 +70,9 @@
 	  <allow_active>auth_admin_keep</allow_active>
         </defaults>
     </action>
-    <action id="org.selinux.change_policy_type">
-        <description>SELinux write access</description>
-        <message>System policy prevents change_policy_type access to SELinux</message>
+    <action id="org.selinux.change_default_mode">
+        <description>Change SELinux default enforcing mode</description>
+        <message>System policy prevents change_default_policy access to SELinux</message>
         <defaults>
           <allow_any>no</allow_any>
           <allow_inactive>no</allow_inactive>

--- a/libselinux/man/man8/selinux.8
+++ b/libselinux/man/man8/selinux.8
@@ -91,11 +91,13 @@ This manual page was written by Dan Walsh <dwalsh@redhat.com>.
 .BR sepolicy (8),
 .BR system-config-selinux (8),
 .BR togglesebool (8),
-.BR restorecon (8),
 .BR fixfiles (8),
+.BR restorecon (8),
 .BR setfiles (8),
 .BR semanage (8),
 .BR sepolicy (8)
+.BR seinfo (8),
+.BR sesearch (8)
 
 Every confined service on the system has a man page in the following format:
 .br

--- a/libselinux/src/avc_sidtab.c
+++ b/libselinux/src/avc_sidtab.c
@@ -81,6 +81,11 @@ sidtab_context_to_sid(struct sidtab *s,
 	int hvalue, rc = 0;
 	struct sidtab_node *cur;
 
+	if (! ctx) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	*sid = NULL;
 	hvalue = sidtab_hash(ctx);
 

--- a/libselinux/src/booleans.c
+++ b/libselinux/src/booleans.c
@@ -55,6 +55,7 @@ int security_get_boolean_names(char ***names, int *len)
 	snprintf(path, sizeof path, "%s%s", selinux_mnt, SELINUX_BOOL_DIR);
 	*len = scandir(path, &namelist, &filename_select, alphasort);
 	if (*len <= 0) {
+		errno = ENOENT;
 		return -1;
 	}
 

--- a/libselinux/src/canonicalize_context.c
+++ b/libselinux/src/canonicalize_context.c
@@ -17,6 +17,11 @@ int security_canonicalize_context_raw(const char * con,
 	size_t size;
 	int fd, ret;
 
+	if (! con) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	if (!selinux_mnt) {
 		errno = ENOENT;
 		return -1;

--- a/libselinux/src/check_context.c
+++ b/libselinux/src/check_context.c
@@ -14,6 +14,11 @@ int security_check_context_raw(const char * con)
 	char path[PATH_MAX];
 	int fd, ret;
 
+	if (! con) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	if (!selinux_mnt) {
 		errno = ENOENT;
 		return -1;

--- a/libselinux/src/compute_av.c
+++ b/libselinux/src/compute_av.c
@@ -26,6 +26,11 @@ int security_compute_av_flags_raw(const char * scon,
 		return -1;
 	}
 
+	if ((! scon) || (! tcon)) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	snprintf(path, sizeof path, "%s/access", selinux_mnt);
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd < 0)

--- a/libselinux/src/compute_create.c
+++ b/libselinux/src/compute_create.c
@@ -64,6 +64,11 @@ int security_compute_create_name_raw(const char * scon,
 		return -1;
 	}
 
+	if ((! scon) || (! tcon)) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	snprintf(path, sizeof path, "%s/create", selinux_mnt);
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd < 0)

--- a/libselinux/src/compute_member.c
+++ b/libselinux/src/compute_member.c
@@ -25,6 +25,11 @@ int security_compute_member_raw(const char * scon,
 		return -1;
 	}
 
+	if ((! scon) || (! tcon)) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	snprintf(path, sizeof path, "%s/member", selinux_mnt);
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd < 0)

--- a/libselinux/src/compute_relabel.c
+++ b/libselinux/src/compute_relabel.c
@@ -25,6 +25,11 @@ int security_compute_relabel_raw(const char * scon,
 		return -1;
 	}
 
+	if ((! scon) || (! tcon)) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	snprintf(path, sizeof path, "%s/relabel", selinux_mnt);
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd < 0)

--- a/libselinux/src/compute_user.c
+++ b/libselinux/src/compute_user.c
@@ -24,6 +24,11 @@ int security_compute_user_raw(const char * scon,
 		return -1;
 	}
 
+	if (! scon) {
+		errno=EINVAL;
+		return -1;
+	}
+
 	snprintf(path, sizeof path, "%s/user", selinux_mnt);
 	fd = open(path, O_RDWR | O_CLOEXEC);
 	if (fd < 0)

--- a/libselinux/src/fsetfilecon.c
+++ b/libselinux/src/fsetfilecon.c
@@ -9,8 +9,12 @@
 
 int fsetfilecon_raw(int fd, const char * context)
 {
-	int rc = fsetxattr(fd, XATTR_NAME_SELINUX, context, strlen(context) + 1,
-			 0);
+	int rc;
+	if (! context) {
+		errno=EINVAL;
+		return -1;
+	}
+	rc = fsetxattr(fd, XATTR_NAME_SELINUX, context, strlen(context) + 1, 0);
 	if (rc < 0 && errno == ENOTSUP) {
 		char * ccontext = NULL;
 		int err = errno;

--- a/libselinux/src/lsetfilecon.c
+++ b/libselinux/src/lsetfilecon.c
@@ -9,8 +9,13 @@
 
 int lsetfilecon_raw(const char *path, const char * context)
 {
-	int rc = lsetxattr(path, XATTR_NAME_SELINUX, context, strlen(context) + 1,
-			 0);
+	int rc;
+	if (! context) {
+		errno=EINVAL;
+		return -1;
+	}
+
+	rc = lsetxattr(path, XATTR_NAME_SELINUX, context, strlen(context) + 1, 0);
 	if (rc < 0 && errno == ENOTSUP) {
 		char * ccontext = NULL;
 		int err = errno;

--- a/libselinux/src/setfilecon.c
+++ b/libselinux/src/setfilecon.c
@@ -9,8 +9,12 @@
 
 int setfilecon_raw(const char *path, const char * context)
 {
-	int rc = setxattr(path, XATTR_NAME_SELINUX, context, strlen(context) + 1,
-			0);
+	int rc;
+	if (! context) {
+		errno=EINVAL;
+		return -1;
+	}
+	rc = setxattr(path, XATTR_NAME_SELINUX, context, strlen(context) + 1, 0);
 	if (rc < 0 && errno == ENOTSUP) {
 		char * ccontext = NULL;
 		int err = errno;

--- a/libselinux/utils/matchpathcon.c
+++ b/libselinux/utils/matchpathcon.c
@@ -14,7 +14,7 @@
 static __attribute__ ((__noreturn__)) void usage(const char *progname)
 {
 	fprintf(stderr,
-		"usage:  %s [-N] [-n] [-f file_contexts] [ -P policy_root_path ] [-p prefix] [-Vq] path...\n",
+		"usage:  %s [-V] [-N] [-n] [-m type] [-f file_contexts_file] [-p prefix] [-P policy_root_path] filepath...\n",
 		progname);
 	exit(1);
 }

--- a/libsemanage/src/direct_api.c
+++ b/libsemanage/src/direct_api.c
@@ -1481,7 +1481,7 @@ rebuild:
 			retval = semanage_copy_file(path,
 						    semanage_path(SEMANAGE_TMP,
 								  SEMANAGE_STORE_SEUSERS),
-						    sh->conf->file_mode);
+						    0);
 			if (retval < 0)
 				goto cleanup;
 			pseusers->dtable->drop_cache(pseusers->dbase);
@@ -1499,7 +1499,7 @@ rebuild:
 			retval = semanage_copy_file(path,
 						    semanage_path(SEMANAGE_TMP,
 								  SEMANAGE_USERS_EXTRA),
-						    sh->conf->file_mode);
+						    0);
 			if (retval < 0)
 				goto cleanup;
 			pusers_extra->dtable->drop_cache(pusers_extra->dbase);

--- a/policycoreutils/scripts/fixfiles
+++ b/policycoreutils/scripts/fixfiles
@@ -108,6 +108,7 @@ exclude_dirs_from_relabelling() {
 fullFlag=0
 BOOTTIME=""
 VERBOSE="-p"
+[ -t 1 ] || VERBOSE=""
 FORCEFLAG=""
 RPMFILES=""
 PREFC=""

--- a/python/semanage/semanage.8
+++ b/python/semanage/semanage.8
@@ -57,9 +57,8 @@ to SELinux user identities (which controls the initial security context
 assigned to Linux users when they login and bounds their authorized role set)
 as well as security context mappings for various kinds of objects, such
 as network ports, interfaces, infiniband pkeys and endports, and nodes (hosts)
-as well as the file context mapping. See the EXAMPLES section below for some
-examples of common usage.  Note that the semanage login command deals with the
-mapping from Linux usernames (logins) to SELinux user identities,
+as well as the file context mapping. Note that the semanage login command deals
+with the mapping from Linux usernames (logins) to SELinux user identities,
 while the semanage user command deals with the mapping from SELinux
 user identities to authorized role sets.  In most cases, only the
 former mapping needs to be adjusted by the administrator; the latter

--- a/python/semanage/seobject.py
+++ b/python/semanage/seobject.py
@@ -2651,7 +2651,7 @@ class booleanRecords(semanageRecords):
             self.current_booleans = []
             ptype = None
 
-        if self.store is None or self.store == ptype:
+        if self.store is "" or self.store == ptype:
             self.modify_local = True
         else:
             self.modify_local = False

--- a/python/sepolicy/sepolicy/__init__.py
+++ b/python/sepolicy/sepolicy/__init__.py
@@ -1163,7 +1163,7 @@ def get_os_version():
     system_release = ""
     try:
         with open('/etc/system-release') as f:
-            system_release = f.readline()
+            system_release = f.readline().rstrip()
     except IOError:
         system_release = "Misc"
 

--- a/python/sepolicy/sepolicy/__init__.py
+++ b/python/sepolicy/sepolicy/__init__.py
@@ -1160,27 +1160,14 @@ def boolean_desc(boolean):
 
 
 def get_os_version():
-    os_version = ""
-    pkg_name = "selinux-policy"
+    system_release = ""
     try:
-        try:
-            from commands import getstatusoutput
-        except ImportError:
-            from subprocess import getstatusoutput
-        rc, output = getstatusoutput("rpm -q '%s'" % pkg_name)
-        if rc == 0:
-            os_version = output.split(".")[-2]
-    except:
-        os_version = ""
+        with open('/etc/system-release') as f:
+            system_release = f.readline()
+    except IOError:
+        system_release = "Misc"
 
-    if os_version[0:2] == "fc":
-        os_version = "Fedora" + os_version[2:]
-    elif os_version[0:2] == "el":
-        os_version = "RHEL" + os_version[2:]
-    else:
-        os_version = ""
-
-    return os_version
+    return system_release
 
 
 def reinit():

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -794,7 +794,8 @@ SELinux %(domainname)s policy is very flexible allowing users to setup their %(d
 .PP
 """ % {'domainname': self.domainname, 'equiv': e, 'alt': e.split('/')[-1]})
 
-        self.fd.write(r"""
+        if flist_non_exec:
+                self.fd.write(r"""
 .PP
 .B STANDARD FILE CONTEXT
 

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -126,8 +126,24 @@ def gen_domains():
     domains.sort()
     return domains
 
-types = None
 
+exec_types = None
+
+def _gen_exec_types():
+    global exec_types
+    if exec_types is None:
+        exec_types = next(sepolicy.info(sepolicy.ATTRIBUTE, "exec_type"))["types"]
+    return exec_types
+
+entry_types = None
+
+def _gen_entry_types():
+    global entry_types
+    if entry_types is None:
+        entry_types = next(sepolicy.info(sepolicy.ATTRIBUTE, "entry_type"))["types"]
+    return entry_types
+
+types = None
 
 def _gen_types():
     global types
@@ -373,6 +389,8 @@ class ManPage:
         self.all_file_types = sepolicy.get_all_file_types()
         self.role_allows = sepolicy.get_all_role_allows()
         self.types = _gen_types()
+        self.exec_types = _gen_exec_types()
+        self.entry_types = _gen_entry_types()
 
         if self.source_files:
             self.fcpath = self.root + "file_contexts"
@@ -690,7 +708,7 @@ Default Defined Ports:""")
         for f in self.all_file_types:
             if f.startswith(self.domainname):
                 flist.append(f)
-                if not file_type_is_executable(f) or not file_type_is_entrypoint(f):
+                if not f in self.exec_types or not f in self.entry_types:
                     flist_non_exec.append(f)
                 if f in self.fcdict:
                     mpaths = mpaths + self.fcdict[f]["regex"]

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -143,6 +143,15 @@ def _gen_entry_types():
         entry_types = next(sepolicy.info(sepolicy.ATTRIBUTE, "entry_type"))["types"]
     return entry_types
 
+mcs_constrained_types = None
+
+def _gen_mcs_constrained_types():
+    global mcs_constrained_types
+    if mcs_constrained_types is None:
+        mcs_constrained_types = next(sepolicy.info(sepolicy.ATTRIBUTE, "mcs_constrained_type"))
+    return mcs_constrained_types
+
+
 types = None
 
 def _gen_types():
@@ -391,6 +400,7 @@ class ManPage:
         self.types = _gen_types()
         self.exec_types = _gen_exec_types()
         self.entry_types = _gen_entry_types()
+        self.mcs_constrained_types = _gen_mcs_constrained_types()
 
         if self.source_files:
             self.fcpath = self.root + "file_contexts"
@@ -945,11 +955,7 @@ All executeables with the default executable label, usually stored in /usr/bin a
 %s""" % ", ".join(paths))
 
     def _mcs_types(self):
-        try:
-            mcs_constrained_type = next(sepolicy.info(sepolicy.ATTRIBUTE, "mcs_constrained_type"))
-        except StopIteration:
-            return
-        if self.type not in mcs_constrained_type['types']:
+        if self.type not in self.mcs_constrained_types['types']:
             return
         self.fd.write ("""
 .SH "MCS Constrained"

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -221,7 +221,7 @@ class HTMLManPages:
 <html>
 <head>
 	<link rel=stylesheet type="text/css" href="style.css" title="style">
-	<title>SELinux man pages online</title>
+	<title>SELinux man pages</title>
 </head>
 <body>
 <h1>SELinux man pages for %s</h1>

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -736,10 +736,13 @@ Default Defined Ports:""")
 
     def _file_context(self):
         flist = []
+        flist_non_exec = []
         mpaths = []
         for f in self.all_file_types:
             if f.startswith(self.domainname):
                 flist.append(f)
+                if not file_type_is_executable(f) or not file_type_is_entrypoint(f):
+                    flist_non_exec.append(f)
                 if f in self.fcdict:
                     mpaths = mpaths + self.fcdict[f]["regex"]
         if len(mpaths) == 0:
@@ -798,12 +801,12 @@ SELinux %(domainname)s policy is very flexible allowing users to setup their %(d
 SELinux defines the file context types for the %(domainname)s, if you wanted to
 store files with these types in a diffent paths, you need to execute the semanage command to sepecify alternate labeling and then use restorecon to put the labels on disk.
 
-.B semanage fcontext -a -t %(type)s '/srv/%(domainname)s/content(/.*)?'
+.B semanage fcontext -a -t %(type)s '/srv/my%(domainname)s_content(/.*)?'
 .br
 .B restorecon -R -v /srv/my%(domainname)s_content
 
 Note: SELinux often uses regular expressions to specify labels that match multiple files.
-""" % {'domainname': self.domainname, "type": flist[0]})
+""" % {'domainname': self.domainname, "type": flist_non_exec[-1]})
 
         self.fd.write(r"""
 .I The following file types are defined for %(domainname)s:

--- a/python/sepolicy/sepolicy/manpage.py
+++ b/python/sepolicy/sepolicy/manpage.py
@@ -150,10 +150,6 @@ def prettyprint(f, trim):
 manpage_domains = []
 manpage_roles = []
 
-fedora_releases = ["Fedora17", "Fedora18"]
-rhel_releases = ["RHEL6", "RHEL7"]
-
-
 def get_alphabet_manpages(manpage_list):
     alphabet_manpages = dict.fromkeys(string.ascii_letters, [])
     for i in string.ascii_letters:
@@ -183,7 +179,7 @@ def convert_manpage_to_html(html_manpage, manpage):
 class HTMLManPages:
 
     """
-            Generate a HHTML Manpages on an given SELinux domains
+            Generate a HTML Manpages on an given SELinux domains
     """
 
     def __init__(self, manpage_roles, manpage_domains, path, os_version):
@@ -191,9 +187,9 @@ class HTMLManPages:
         self.manpage_domains = get_alphabet_manpages(manpage_domains)
         self.os_version = os_version
         self.old_path = path + "/"
-        self.new_path = self.old_path + self.os_version + "/"
+        self.new_path = self.old_path
 
-        if self.os_version in fedora_releases or self.os_version in rhel_releases:
+        if self.os_version:
             self.__gen_html_manpages()
         else:
             print("SELinux HTML man pages can not be generated for this %s" % os_version)
@@ -202,7 +198,6 @@ class HTMLManPages:
     def __gen_html_manpages(self):
         self._write_html_manpage()
         self._gen_index()
-        self._gen_body()
         self._gen_css()
 
     def _write_html_manpage(self):
@@ -220,67 +215,21 @@ class HTMLManPages:
                     convert_manpage_to_html((self.new_path + r.rsplit("_selinux", 1)[0] + ".html"), self.old_path + r)
 
     def _gen_index(self):
-        index = self.old_path + "index.html"
-        fd = open(index, 'w')
-        fd.write("""
-<html>
-<head>
-    <link rel=stylesheet type="text/css" href="style.css" title="style">
-    <title>SELinux man pages online</title>
-</head>
-<body>
-<h1>SELinux man pages</h1>
-<br></br>
-Fedora or Red Hat Enterprise Linux Man Pages.</h2>
-<br></br>
-<hr>
-<h3>Fedora</h3>
-<table><tr>
-<td valign="middle">
-</td>
-</tr></table>
-<pre>
-""")
-        for f in fedora_releases:
-            fd.write("""
-<a href=%s/%s.html>%s</a> - SELinux man pages for %s """ % (f, f, f, f))
-
-        fd.write("""
-</pre>
-<hr>
-<h3>RHEL</h3>
-<table><tr>
-<td valign="middle">
-</td>
-</tr></table>
-<pre>
-""")
-        for r in rhel_releases:
-            fd.write("""
-<a href=%s/%s.html>%s</a> - SELinux man pages for %s """ % (r, r, r, r))
-
-        fd.write("""
-</pre>
-	""")
-        fd.close()
-        print("%s has been created" % index)
-
-    def _gen_body(self):
         html = self.new_path + self.os_version + ".html"
         fd = open(html, 'w')
         fd.write("""
 <html>
 <head>
-	<link rel=stylesheet type="text/css" href="../style.css" title="style">
-	<title>Linux man-pages online for Fedora18</title>
+	<link rel=stylesheet type="text/css" href="style.css" title="style">
+	<title>SELinux man pages online</title>
 </head>
 <body>
-<h1>SELinux man pages for Fedora18</h1>
+<h1>SELinux man pages for %s</h1>
 <hr>
 <table><tr>
 <td valign="middle">
 <h3>SELinux roles</h3>
-""")
+""" % self.os_version)
         for letter in self.manpage_roles:
             if len(self.manpage_roles[letter]):
                 fd.write("""

--- a/sandbox/sandboxX.sh
+++ b/sandbox/sandboxX.sh
@@ -20,7 +20,7 @@ cat > ~/.config/openbox/rc.xml << EOF
 </openbox_config>
 EOF
 
-(/usr/bin/Xephyr -resizeable -title "$TITLE" -terminate -screen $SCREENSIZE -dpi $DPI -nolisten tcp -displayfd 5 5>&1 2>/dev/null) | while read D; do
+(/usr/bin/Xephyr -resizeable -title "$TITLE" -terminate -reset -screen $SCREENSIZE -dpi $DPI -nolisten tcp -displayfd 5 5>&1 2>/dev/null) | while read D; do
     export DISPLAY=:$D
     cat > ~/seremote << __EOF
 #!/bin/sh


### PR DESCRIPTION
Commit 8702a865e08b5660561e194a83e4a363061edc03 causes file mode of
seusers and users_extra to change based on the value defined in config
file whenever direct_commit is called and policy is not rebuilt.
(e.g. when setting a boolean).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1512639

$ ll /var/lib/selinux/targeted/active/users_extra
-rw-------. 1 root root 101 11. dub 17.31 /var/lib/selinux/targeted/active/users_extra
$ ll /var/lib/selinux/targeted/active/seusers
-rw-------. 1 root root 73 11. dub 17.31 /var/lib/selinux/targeted/active/seusers
$ semanage boolean -m --on httpd_can_network_connect
$ ll /var/lib/selinux/targeted/active/seusers
-rw-r--r--. 1 root root 73 23. bře 16.59 /var/lib/selinux/targeted/active/seusers
$ ll /var/lib/selinux/targeted/active/users_extra
-rw-r--r--. 1 root root 101 23. bře 16.59 /var/lib/selinux/targeted/active/users_extra
$ rpm -Vq selinux-policy-targeted
.M.....T.    /var/lib/selinux/targeted/active/seusers
.M.....T.    /var/lib/selinux/targeted/active/users_extra

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>