### PR TITLE
python/sepolicy: Fix get_real_type_name to handle query failure properly

### DIFF
--- a/python/sepolicy/sepolicy/__init__.py
+++ b/python/sepolicy/sepolicy/__init__.py
@@ -452,9 +452,8 @@ def get_file_types(setype):
 def get_real_type_name(name):
     try:
         return next(info(TYPE, name))["name"]
-    except RuntimeError:
+    except (RuntimeError, StopIteration):
         return None
-
 
 def get_writable_files(setype):
     file_types = get_all_file_types()


### PR DESCRIPTION
Setools 4 no longer emits RuntimeError when TypeQuery fails, which causes
the following failure when searching for nonexistent type:

File "/usr/lib/python3.7/site-packages/sepolicy/__init__.py", line 454, in get_real_type_name
    return next(info(TYPE, name))["name"]
StopIteration