### PR TITLE
Fix typo in d3f8b2c3cd9e044aba909f63a2ca78f53db11fe0

### DIFF
--- a/policycoreutils/scripts/fixfiles
+++ b/policycoreutils/scripts/fixfiles
@@ -215,7 +215,7 @@ OPTION=$1
 shift
 
 # [-B | -N time ]
-if [ -z "$BOOTTIME" ]; then
+if [ -n "$BOOTTIME" ]; then
 	newer $BOOTTIME $*
 	return
 fi


### PR DESCRIPTION
"BOOTTIME" needs to contain a non-zero string in order for "newer()" not
to fail.

Fixes:
        #fixfiles relabel
        /sbin/fixfiles: line 151: $1: unbound variable