### PR TITLE
python/sepolicy: Cache conditional rule queries

### DIFF
--- a/python/sepolicy/sepolicy/__init__.py
+++ b/python/sepolicy/sepolicy/__init__.py
@@ -125,6 +125,7 @@ all_attributes = None
 booleans = None
 booleans_dict = None
 all_allow_rules = None
+all_bool_rules = None
 all_transitions = None
 
 
@@ -1136,6 +1137,14 @@ def get_all_allow_rules():
         all_allow_rules = search([ALLOW])
     return all_allow_rules
 
+def get_all_bool_rules():
+    global all_bool_rules
+    if not all_bool_rules:
+        q = TERuleQuery(_pol, boolean=".*", boolean_regex=True,
+                                ruletype=[ALLOW, DONTAUDIT])
+        all_bool_rules = [_setools_rule_to_dict(x) for x in q.results()]
+    return all_bool_rules
+
 def get_all_transitions():
     global all_transitions
     if not all_transitions:
@@ -1146,7 +1155,7 @@ def get_bools(setype):
     bools = []
     domainbools = []
     domainname, short_name = gen_short_name(setype)
-    for i in map(lambda x: x['booleans'], filter(lambda x: 'booleans' in x and x['source'] == setype, search([ALLOW, DONTAUDIT]))):
+    for i in map(lambda x: x['booleans'], filter(lambda x: 'booleans' in x and x['source'] == setype, get_all_bool_rules())):
         for b in i:
             if not isinstance(b, tuple):
                 continue


### PR DESCRIPTION
Commit 7506771e4b630fe0ab853f96574e039055cb72eb
"add missing booleans to man pages" dramatically slowed down "sepolicy manpage -a" by removing caching of setools rule query. Re-add said caching and update the query to only return conditional rules.

Before commit 7506771e:
 #time sepolicy manpage -a
 real	1m43.153s
 # time sepolicy manpage -d httpd_t
 real	0m4.493s

After commit 7506771e:
 #time sepolicy manpage -a
 real   1h56m43.153s
 # time sepolicy manpage -d httpd_t
 real	0m8.352s

After this commit:
 #time sepolicy manpage -a
 real	1m41.074s
 # time sepolicy manpage -d httpd_t
 real	0m7.358s

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>