### PR TITLE
restorecond.service: Move to simple type

### DIFF
--- a/restorecond/restorecond.8
+++ b/restorecond/restorecond.8
@@ -3,7 +3,7 @@
 restorecond \- daemon that watches for file creation and then sets the default SELinux file context
 
 .SH "SYNOPSIS"
-.B restorecond  [\-d] [-h] [\-f restorecond_file ] [\-u] [\-v]
+.B restorecond  [\-d] [-h] [\-f restorecond_file ] [\-F] [\-u] [\-v]
 .P
 
 .SH "DESCRIPTION"
@@ -25,6 +25,9 @@ Print usage statement.
 .TP
 .B \-f restorecond_file
 Use alternative restorecond.conf file.
+.TP
+.B \-F
+Run in foreground, do not become a daemon.
 .TP
 .B \-u
 Turns on user mode.  Runs restorecond in the user session and reads /etc/selinux/restorecond_user.conf.  Uses dbus to make sure only one restorecond is running per user session.

--- a/restorecond/restorecond.c
+++ b/restorecond/restorecond.c
@@ -76,6 +76,7 @@ int debug_mode = 0;
 int terminate = 0;
 int master_wd = -1;
 int run_as_user = 0;
+int foreground_mode = 0;
 
 static void done(void) {
 	watch_list_free(master_fd);
@@ -124,7 +125,7 @@ static void term_handler(int s __attribute__ ((unused)))
 
 static void usage(char *program)
 {
-	printf("%s [-d] [-f restorecond_file ] [-u] [-v] \n", program);
+	printf("%s [-d] [-f restorecond_file ] [-F] [-n] [-u] [-v] \n", program);
 }
 
 void exitApp(const char *msg)
@@ -165,13 +166,16 @@ int main(int argc, char **argv)
 	sigaction(SIGTERM, &sa, NULL);
 
 	atexit( done );
-	while ((opt = getopt(argc, argv, "hdf:uv")) > 0) {
+	while ((opt = getopt(argc, argv, "hdf:Fuv")) > 0) {
 		switch (opt) {
 		case 'd':
 			debug_mode = 1;
 			break;
 		case 'f':
 			watch_file = optarg;
+			break;
+		case 'F':
+			foreground_mode = 1;
 			break;
 		case 'u':
 			run_as_user = 1;
@@ -209,12 +213,11 @@ int main(int argc, char **argv)
 
 	read_config(master_fd, watch_file);
 
-	if (!debug_mode) {
+	if (!debug_mode && !foreground_mode) {
 		if (daemon(0, 0) < 0)
 			exitApp("daemon");
+		write_pid_file();
 	}
-
-	write_pid_file();
 
 	while (watch(master_fd, watch_file) == 0) {
 	}

--- a/restorecond/restorecond.service
+++ b/restorecond/restorecond.service
@@ -5,9 +5,8 @@ ConditionPathExists=/etc/selinux/restorecond.conf
 ConditionSecurity=selinux
 
 [Service]
-Type=forking
-ExecStart=/usr/sbin/restorecond
-PIDFile=/run/restorecond.pid
+Type=simple
+ExecStart=/usr/sbin/restorecond -F
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There's a race condition when daemon() in parent process immediately
exits while pid file is not created or updated. Using Type=forking it
can confuse systemd which tries to open non-existing pid file. It's
better to run restocond in foreground and use Type=simple

Fixes:

    openat(80</run>, "restorecond.pid", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_PATH) = -1 ENOENT (No such file or directory) <0.000006>