### PR TITLE
libsepol: Fix memory leak in role_dominates_copy_callback

### DIFF
--- a/libsepol/src/expand.c
+++ b/libsepol/src/expand.c
@@ -827,8 +827,10 @@ static int role_dominates_copy_callback(hashtab_key_t key __attribute__ ((unused
 
 	if (map_ebitmap(&role->dominates, &mapped, state->rolemap))
 		return -1;
-	if (ebitmap_union(&new_role->dominates, &mapped))
+	if (ebitmap_union(&new_role->dominates, &mapped)) {
+		ebitmap_destroy(&mapped);
 		return -1;
+	}
 	ebitmap_destroy(&mapped);
 
 	return 0;


### PR DESCRIPTION
Free memory allocated by map_ebitmap in case ebitmap_union fails.

Fixes:
  Defect type: RESOURCE_LEAK
  libsepol-3.10/src/expand.c:828:2: alloc_arg: "map_ebitmap" allocates memory that is stored into "mapped.node".
  libsepol-3.10/src/expand.c:68:3: alloc_arg: "ebitmap_set_bit" allocates memory that is stored into "dst->node".
  libsepol-3.10/src/ebitmap.c:420:2: alloc_fn: Storage is returned from allocation function "malloc".
  libsepol-3.10/src/ebitmap.c:420:2: assign: Assigning: "new" = "(ebitmap_node_t *)malloc(24UL)".
  libsepol-3.10/src/ebitmap.c:437:3: assign: Assigning: "e->node" = "new".
  libsepol-3.10/src/expand.c:831:3: leaked_storage: Variable "mapped" going out of scope leaks the storage "mapped.node" points to.
  \#   829|   		return -1;
  \#   830|   	if (ebitmap_union(&new_role->dominates, &mapped))
  \#   831|-> 		return -1;
  \#   832|   	ebitmap_destroy(&mapped);
  \#   833|


Acked-by: Petr Lautrbach <lautrbach@redhat.com>

Please read [CONTRIBUTING.md](https://github.com/SELinuxProject/selinux/blob/main/CONTRIBUTING.md)

## Contributing Code

Post the patch for the review to the
[SELinux mailing list](https://lore.kernel.org/selinux) at
[selinux@vger.kernel.org](mailto:selinux@vger.kernel.org).

When preparing patches, please follow these guidelines:

-   Patches should apply with git am
-   Must apply against HEAD of the main branch
-   Separate large patches into logical patches
-   Patch descriptions must end with your "Signed-off-by" line. This means your
    code meets the Developer's certificate of origin, see below.
