### PR TITLE
semodule-utils: add bad-data tests for sefcontext_compile

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,6 +82,19 @@ jobs:
         eval make test $EXPLICIT_MAKE_VARS
         echo "::endgroup::"
 
+        # semodule_package bad-data: unreadable -m/-f inputs need non-root (root reads mode 000).
+        if [ "${{ matrix.python-ruby-version.other }}" != "sanitizers" ] ; then
+          echo "::group::semodule-utils bad-data (non-root)"
+          sudo useradd -m -s /usr/sbin/nologin bad-data-test 2>/dev/null || true
+          # World-readable checkout; run via relative path (inherited CWD). Do not
+          # cd to $PWD — bad-data-test cannot traverse /home/runner/work/... .
+          chmod -R a+rX .
+          sudo runuser -u bad-data-test -- env PATH="$PATH" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
+            ./semodule-utils/tests/bad-data/run.sh
+          sudo userdel -r bad-data-test 2>/dev/null || true
+          echo "::endgroup::"
+        fi
+
         if [ "${{ matrix.python-ruby-version.other }}" != "sanitizers" ] ; then
             # Test Python and Ruby wrappers
             echo "::group::Test Python and Ruby wrappers"

--- a/semodule-utils/Makefile
+++ b/semodule-utils/Makefile
@@ -6,3 +6,4 @@ all install relabel clean:
 	done
 
 test:
+	./tests/bad-data/run.sh

--- a/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_context.mod.fc
+++ b/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_context.mod.fc
@@ -1,0 +1,1 @@
+/usr/bin/bad	not_a_valid_selinux_context

--- a/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_fields.mod.fc
+++ b/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_fields.mod.fc
@@ -1,0 +1,1 @@
+only_one_field_on_this_line

--- a/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_mls.mod.fc
+++ b/semodule-utils/tests/bad-data/fixtures/file_contexts/bad_mls.mod.fc
@@ -1,0 +1,1 @@
+/usr/bin/bad_mls	--	system_u:object_r:test_good_exec_t:s0:c999

--- a/semodule-utils/tests/bad-data/fixtures/file_contexts/good.mod.fc
+++ b/semodule-utils/tests/bad-data/fixtures/file_contexts/good.mod.fc
@@ -1,0 +1,1 @@
+/usr/bin/test_good	--	system_u:object_r:test_good_exec_t:s0

--- a/semodule-utils/tests/bad-data/fixtures/modules/good.te
+++ b/semodule-utils/tests/bad-data/fixtures/modules/good.te
@@ -1,0 +1,8 @@
+module test_good 1.0;
+
+require {
+	type test_good_t;
+	class file { read };
+}
+
+allow test_good_t self:file read;

--- a/semodule-utils/tests/bad-data/run.sh
+++ b/semodule-utils/tests/bad-data/run.sh
@@ -1,0 +1,355 @@
+#!/bin/sh
+#
+# Bad-data tests for semodule_package in the modular policy packaging pipeline.
+# Covers packaging path edge cases (-m/-f) and documents deferred rejection of bad
+# .mod.fc content (enforced later by sefcontext_compile).
+# Unreadable -m/-f cases skip when run as root; CI runs this script as non-root.
+#
+
+set -u
+
+# Prefer an absolute script dir, but keep a relative dirname when cd fails.
+# Non-root CI can inherit the repo as CWD without being able to traverse
+# /home/runner/work/...; relative paths from that CWD still work.
+BASEDIR=$(dirname -- "$0")
+ABS_BASEDIR=$(CDPATH= cd -- "${BASEDIR}" 2>/dev/null && pwd) || ABS_BASEDIR=
+if [ -n "${ABS_BASEDIR}" ]; then
+	BASEDIR="${ABS_BASEDIR}"
+fi
+FIXTURES="${BASEDIR}/fixtures"
+if [ ! -d "${FIXTURES}" ]; then
+	echo "FAIL: cannot resolve fixtures directory (\$0=$0 BASEDIR=${BASEDIR})" >&2
+	exit 1
+fi
+OUTDIR=$(mktemp -d "${TMPDIR:-/tmp}/semodule-package-bad-data.XXXXXX")
+PASS=0
+FAIL=0
+
+CHECKMODULE=${CHECKMODULE:-checkmodule}
+# Modular TE for MCS/MLS builds (checkmodule -M -m).
+CHECKMODULE_MOD_FLAGS=${CHECKMODULE_MOD_FLAGS:--M -m}
+SEMODULE_PACKAGE=${SEMODULE_PACKAGE:-semodule_package}
+
+GOOD_TE="${FIXTURES}/modules/good.te"
+GOOD_MOD="${OUTDIR}/test_good.mod"
+
+cleanup() {
+	rm -rf "${OUTDIR}"
+}
+trap cleanup EXIT
+
+die() {
+	echo "FAIL: $*" >&2
+	FAIL=$((FAIL + 1))
+}
+
+pass() {
+	echo "==== $*"
+	PASS=$((PASS + 1))
+	echo ""
+}
+
+build_good_mod() {
+	echo "==== Setup: build control module ${GOOD_MOD} from good.te"
+	rm -f "${GOOD_MOD}"
+
+	set +e
+	# shellcheck disable=SC2086
+	"${CHECKMODULE}" ${CHECKMODULE_MOD_FLAGS} -o "${GOOD_MOD}" "${GOOD_TE}" \
+		2>"${OUTDIR}/build_good.err"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -ne 0 ]; then
+		echo "FAIL: could not build control module from ${GOOD_TE}" >&2
+		cat "${OUTDIR}/build_good.err" >&2
+		exit 1
+	fi
+	if [ ! -s "${GOOD_MOD}" ]; then
+		echo "FAIL: ${GOOD_MOD} is empty" >&2
+		exit 1
+	fi
+	echo ""
+}
+
+expect_package_pass() {
+	desc="$1"
+	outname="$2"
+	shift 2
+
+	outpp="${OUTDIR}/${outname}.pp"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== POSITIVE (expect semodule_package success): ${desc}"
+	rm -f "${outpp}"
+
+	set +e
+	"${SEMODULE_PACKAGE}" -o "${outpp}" "$@" 2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -ne 0 ]; then
+		echo "stderr:" >&2
+		cat "${stderr}" >&2
+		die "${desc}: expected exit 0, got rc=${rc}"
+		return 0
+	fi
+	if [ ! -s "${outpp}" ]; then
+		die "${desc}: expected non-empty ${outpp}"
+		return 0
+	fi
+
+	pass "${desc} (exit 0, .pp created)"
+}
+
+expect_package_pass_deferred() {
+	desc="$1"
+	outname="$2"
+	shift 2
+
+	outpp="${OUTDIR}/${outname}.pp"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== DOCUMENT (semodule_package accepts input; validate in sefcontext_compile): ${desc}"
+	rm -f "${outpp}"
+
+	set +e
+	"${SEMODULE_PACKAGE}" -o "${outpp}" "$@" 2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -ne 0 ]; then
+		echo "stderr:" >&2
+		cat "${stderr}" >&2
+		die "${desc}: expected exit 0 at packaging stage, got rc=${rc}"
+		return 0
+	fi
+	if [ ! -s "${outpp}" ]; then
+		die "${desc}: expected non-empty ${outpp} at packaging stage"
+		return 0
+	fi
+
+	pass "${desc} (packaging exit 0; labeling validation deferred to sefcontext_compile)"
+}
+
+expect_package_fail() {
+	desc="$1"
+	pattern="$2"
+	outname="$3"
+	shift 3
+
+	outpp="${OUTDIR}/${outname}.pp"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== NEGATIVE (expect semodule_package failure): ${desc}"
+	rm -f "${outpp}"
+
+	set +e
+	"${SEMODULE_PACKAGE}" -o "${outpp}" "$@" 2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -eq 0 ]; then
+		die "${desc}: expected non-zero exit, got rc=0"
+		return 0
+	fi
+	if [ -f "${outpp}" ]; then
+		die "${desc}: did not expect output ${outpp}"
+		return 0
+	fi
+	if ! grep -Eq "${pattern}" "${stderr}"; then
+		echo "FAIL: stderr did not match /${pattern}/" >&2
+		cat "${stderr}" >&2
+		FAIL=$((FAIL + 1))
+		return 0
+	fi
+
+	pass "${desc} (rejected as expected, rc=${rc})"
+}
+
+expect_package_fail_unreadable() {
+	desc="unreadable -m file"
+	mod="${OUTDIR}/unreadable.mod"
+	outpp="${OUTDIR}/unreadable.pp"
+	stderr="${OUTDIR}/unreadable.err"
+
+	echo "==== NEGATIVE (expect semodule_package failure): ${desc}"
+	if [ "$(id -u)" -eq 0 ]; then
+		echo "SKIP: root can read mode 000 files; unreadable check is non-root only"
+		PASS=$((PASS + 1))
+		echo ""
+		return 0
+	fi
+
+	rm -f "${outpp}"
+	cp "${GOOD_MOD}" "${mod}"
+	chmod 000 "${mod}"
+
+	set +e
+	"${SEMODULE_PACKAGE}" -o "${outpp}" -m "${mod}" 2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -eq 0 ]; then
+		die "${desc}: expected non-zero exit, got rc=0"
+		return 0
+	fi
+	if [ -f "${outpp}" ]; then
+		die "${desc}: did not expect output ${outpp}"
+		return 0
+	fi
+	if ! grep -Eq 'Permission denied|Could not open|Failed to open' "${stderr}"; then
+		echo "FAIL: stderr did not mention permission or open failure" >&2
+		cat "${stderr}" >&2
+		FAIL=$((FAIL + 1))
+		return 0
+	fi
+
+	pass "${desc} (rejected as expected, rc=${rc})"
+}
+
+expect_package_fail_unreadable_fc() {
+	desc="unreadable -f file"
+	fc="${OUTDIR}/unreadable.mod.fc"
+	outpp="${OUTDIR}/unreadable_fc.pp"
+	stderr="${OUTDIR}/unreadable_fc.err"
+
+	echo "==== NEGATIVE (expect semodule_package failure): ${desc}"
+	if [ "$(id -u)" -eq 0 ]; then
+		echo "SKIP: root can read mode 000 files; unreadable check is non-root only"
+		PASS=$((PASS + 1))
+		echo ""
+		return 0
+	fi
+
+	rm -f "${outpp}"
+	cp "${GOOD_FC}" "${fc}"
+	chmod 000 "${fc}"
+
+	set +e
+	"${SEMODULE_PACKAGE}" -o "${outpp}" -m "${GOOD_MOD}" -f "${fc}" \
+		2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -eq 0 ]; then
+		die "${desc}: expected non-zero exit, got rc=0"
+		return 0
+	fi
+	if [ -f "${outpp}" ]; then
+		die "${desc}: did not expect output ${outpp}"
+		return 0
+	fi
+	if ! grep -Eq 'Permission denied|Could not open|Failed to open' "${stderr}"; then
+		echo "FAIL: stderr did not mention permission or open failure" >&2
+		cat "${stderr}" >&2
+		FAIL=$((FAIL + 1))
+		return 0
+	fi
+
+	pass "${desc} (rejected as expected, rc=${rc})"
+}
+
+build_good_mod
+
+# Ephemeral path fixtures for packaging path tests.
+ln -sf /nonexistent/test_good.mod "${OUTDIR}/broken_symlink.mod"
+ln -sf /nonexistent/test_good.mod.fc "${OUTDIR}/broken_symlink.mod.fc"
+printf '' > "${OUTDIR}/empty.mod.fc"
+
+# NUL byte inside path column (packaging accepts; sefcontext_compile rejects).
+printf '/bin/foo\x00bar\t--\tsystem_u:object_r:test_good_exec_t:s0\n' \
+	> "${OUTDIR}/nul_bytes.mod.fc"
+
+GOOD_FC="${FIXTURES}/file_contexts/good.mod.fc"
+
+# --- semodule_package input paths ---
+expect_package_pass \
+	"control good .mod without file contexts" \
+	good_mod \
+	-m "${GOOD_MOD}"
+
+expect_package_pass \
+	"control good .mod with good .mod.fc" \
+	good_mod_fc \
+	-m "${GOOD_MOD}" -f "${GOOD_FC}"
+
+expect_package_fail \
+	"missing -m path" \
+	"Could not open|Failed to open" \
+	missing_mod \
+	-m "${OUTDIR}/does_not_exist.mod"
+
+expect_package_fail \
+	"missing -f path" \
+	"Failed to open|Could not open" \
+	missing_fc \
+	-m "${GOOD_MOD}" -f "${OUTDIR}/does_not_exist.mod.fc"
+
+expect_package_fail \
+	"directory instead of -m file" \
+	"Error while reading policy module|Could not open" \
+	directory_mod \
+	-m "${BASEDIR}"
+
+expect_package_fail \
+	"broken symlink for -m" \
+	"Could not open|Failed to open|No such file" \
+	symlink_mod \
+	-m "${OUTDIR}/broken_symlink.mod"
+
+expect_package_fail_unreadable
+
+expect_package_fail \
+	"empty -m path argument" \
+	"Could not open|Failed to open" \
+	empty_mod \
+	-m ""
+
+expect_package_fail \
+	"directory instead of -f file" \
+	"Permission denied|Failed to mmap|Failed to open|Could not open" \
+	directory_fc \
+	-m "${GOOD_MOD}" -f "${BASEDIR}"
+
+expect_package_fail \
+	"broken symlink for -f" \
+	"Could not open|Failed to open|No such file" \
+	symlink_fc \
+	-m "${GOOD_MOD}" -f "${OUTDIR}/broken_symlink.mod.fc"
+
+expect_package_fail_unreadable_fc
+
+expect_package_fail \
+	"empty -f path argument" \
+	"Could not open|Failed to open" \
+	empty_fc_arg \
+	-m "${GOOD_MOD}" -f ""
+
+# --- bad .mod.fc at packaging time ---
+expect_package_pass_deferred \
+	"invalid SELinux context in .mod.fc" \
+	bad_context \
+	-m "${GOOD_MOD}" -f "${FIXTURES}/file_contexts/bad_context.mod.fc"
+
+expect_package_pass_deferred \
+	"wrong field count in .mod.fc" \
+	bad_fields \
+	-m "${GOOD_MOD}" -f "${FIXTURES}/file_contexts/bad_fields.mod.fc"
+
+expect_package_pass_deferred \
+	"NUL byte in .mod.fc path field" \
+	nul_bytes \
+	-m "${GOOD_MOD}" -f "${OUTDIR}/nul_bytes.mod.fc"
+
+expect_package_pass_deferred \
+	"empty .mod.fc file" \
+	empty_fc \
+	-m "${GOOD_MOD}" -f "${OUTDIR}/empty.mod.fc"
+
+echo "========================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -ne 0 ]; then
+	exit 1
+fi
+exit 0

--- a/semodule-utils/tests/bad-data/run.sh
+++ b/semodule-utils/tests/bad-data/run.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 #
-# Bad-data tests for semodule_package in the modular policy packaging pipeline.
-# Covers packaging path edge cases (-m/-f) and documents deferred rejection of bad
-# .mod.fc content (enforced later by sefcontext_compile).
-# Unreadable -m/-f cases skip when run as root; CI runs this script as non-root.
+# Bad-data tests for semodule_package and sefcontext_compile in the modular
+# policy packaging pipeline. Covers packaging path edge cases (-m/-f), documents
+# deferred rejection of bad .mod.fc content at packaging time, and validates
+# labeling through sefcontext_compile. Unreadable -m/-f cases skip when run as
+# root; CI runs this script as non-root.
 #
 
 set -u
@@ -29,6 +30,8 @@ CHECKMODULE=${CHECKMODULE:-checkmodule}
 # Modular TE for MCS/MLS builds (checkmodule -M -m).
 CHECKMODULE_MOD_FLAGS=${CHECKMODULE_MOD_FLAGS:--M -m}
 SEMODULE_PACKAGE=${SEMODULE_PACKAGE:-semodule_package}
+SEMODULE_UNPACKAGE=${SEMODULE_UNPACKAGE:-semodule_unpackage}
+SEFCONTEXT_COMPILE=${SEFCONTEXT_COMPILE:-sefcontext_compile}
 
 GOOD_TE="${FIXTURES}/modules/good.te"
 GOOD_MOD="${OUTDIR}/test_good.mod"
@@ -250,6 +253,161 @@ expect_package_fail_unreadable_fc() {
 	pass "${desc} (rejected as expected, rc=${rc})"
 }
 
+find_policy_file() {
+	if [ -n "${POLICY_FILE:-}" ] && [ -f "${POLICY_FILE}" ]; then
+		echo "${POLICY_FILE}"
+		return 0
+	fi
+
+	# Prefer the active policy store (SELINUXTYPE); fall back to targeted, then any
+	# installed policy.* (POLICY_FILE overrides all of this).
+	selinuxtype=targeted
+	if [ -r /etc/selinux/config ]; then
+		selinuxtype=$(grep -E '^[[:space:]]*SELINUXTYPE=' /etc/selinux/config 2>/dev/null \
+			| tail -1 | cut -d= -f2- | tr -d ' "')
+		[ -n "${selinuxtype}" ] || selinuxtype=targeted
+	fi
+
+	# shellcheck disable=SC2086
+	set -- /etc/selinux/"${selinuxtype}"/policy/policy.*
+	if [ -f "$1" ]; then
+		echo "$1"
+		return 0
+	fi
+
+	for policy in /etc/selinux/*/policy/policy.*; do
+		[ -f "${policy}" ] || continue
+		echo "${policy}"
+		return 0
+	done
+
+	return 1
+}
+
+expect_sefcontext_pass() {
+	desc="$1"
+	outname="$2"
+	fc="$3"
+	policy="${4:-}"
+
+	outbin="${OUTDIR}/${outname}.bin"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== POSITIVE (expect sefcontext_compile success): ${desc}"
+	rm -f "${outbin}"
+
+	set +e
+	if [ -n "${policy}" ]; then
+		"${SEFCONTEXT_COMPILE}" -p "${policy}" -o "${outbin}" "${fc}" \
+			2>"${stderr}"
+	else
+		"${SEFCONTEXT_COMPILE}" -o "${outbin}" "${fc}" 2>"${stderr}"
+	fi
+	rc=$?
+	set -e
+
+	if [ "${rc}" -ne 0 ]; then
+		cat "${stderr}" >&2
+		die "${desc}: expected exit 0, got rc=${rc}"
+		return 0
+	fi
+	if [ ! -s "${outbin}" ]; then
+		die "${desc}: expected non-empty ${outbin}"
+		return 0
+	fi
+
+	pass "${desc} (sefcontext_compile succeeded)"
+}
+
+expect_sefcontext_fail() {
+	desc="$1"
+	pattern="$2"
+	outname="$3"
+	fc="$4"
+	policy="${5:-}"
+
+	outbin="${OUTDIR}/${outname}.bin"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== NEGATIVE (expect sefcontext_compile failure): ${desc}"
+	rm -f "${outbin}"
+
+	set +e
+	if [ -n "${policy}" ]; then
+		"${SEFCONTEXT_COMPILE}" -p "${policy}" -o "${outbin}" "${fc}" \
+			2>"${stderr}"
+	else
+		"${SEFCONTEXT_COMPILE}" -o "${outbin}" "${fc}" 2>"${stderr}"
+	fi
+	rc=$?
+	set -e
+
+	if [ "${rc}" -eq 0 ]; then
+		die "${desc}: expected non-zero exit, got rc=0"
+		return 0
+	fi
+	if [ -f "${outbin}" ] && [ -s "${outbin}" ]; then
+		die "${desc}: did not expect successful ${outbin}"
+		return 0
+	fi
+	if ! grep -Eq "${pattern}" "${stderr}"; then
+		echo "FAIL: stderr did not match /${pattern}/" >&2
+		cat "${stderr}" >&2
+		FAIL=$((FAIL + 1))
+		return 0
+	fi
+
+	pass "${desc} (rejected as expected, rc=${rc})"
+}
+
+expect_sefcontext_fail_or_skip_no_policy() {
+	desc="$1"
+	pattern="$2"
+	outname="$3"
+	fc="$4"
+
+	policy=$(find_policy_file) || policy=
+	if [ -z "${policy}" ]; then
+		echo "==== SKIP (no binary policy for -p validation): ${desc}"
+		echo "Set POLICY_FILE= to enable this check."
+		PASS=$((PASS + 1))
+		echo ""
+		return 0
+	fi
+
+	expect_sefcontext_fail "${desc}" "${pattern}" "${outname}" "${fc}" \
+		"${policy}"
+}
+
+expect_sefcontext_pass_deferred() {
+	desc="$1"
+	outname="$2"
+	fc="$3"
+
+	outbin="${OUTDIR}/${outname}.bin"
+	stderr="${OUTDIR}/${outname}.err"
+
+	echo "==== DOCUMENT (sefcontext_compile accepts input; complements packaging deferral): ${desc}"
+	rm -f "${outbin}"
+
+	set +e
+	"${SEFCONTEXT_COMPILE}" -o "${outbin}" "${fc}" 2>"${stderr}"
+	rc=$?
+	set -e
+
+	if [ "${rc}" -ne 0 ]; then
+		cat "${stderr}" >&2
+		die "${desc}: expected exit 0 at compile stage, got rc=${rc}"
+		return 0
+	fi
+	if [ ! -s "${outbin}" ]; then
+		die "${desc}: expected non-empty ${outbin} at compile stage"
+		return 0
+	fi
+
+	pass "${desc} (sefcontext_compile exit 0; complements packaging deferral)"
+}
+
 build_good_mod
 
 # Ephemeral path fixtures for packaging path tests.
@@ -258,7 +416,7 @@ ln -sf /nonexistent/test_good.mod.fc "${OUTDIR}/broken_symlink.mod.fc"
 printf '' > "${OUTDIR}/empty.mod.fc"
 
 # NUL byte inside path column (packaging accepts; sefcontext_compile rejects).
-printf '/bin/foo\x00bar\t--\tsystem_u:object_r:test_good_exec_t:s0\n' \
+printf '/bin/foo\000bar\t--\tsystem_u:object_r:test_good_exec_t:s0\n' \
 	> "${OUTDIR}/nul_bytes.mod.fc"
 
 GOOD_FC="${FIXTURES}/file_contexts/good.mod.fc"
@@ -346,6 +504,65 @@ expect_package_pass_deferred \
 	"empty .mod.fc file" \
 	empty_fc \
 	-m "${GOOD_MOD}" -f "${OUTDIR}/empty.mod.fc"
+
+# --- sefcontext_compile / unpackage validation ---
+expect_sefcontext_pass \
+	"control good .mod.fc through sefcontext_compile" \
+	good_fc \
+	"${GOOD_FC}"
+
+expect_sefcontext_fail \
+	"wrong field count in .mod.fc (after packaging)" \
+	"missing fields|process_file failed" \
+	sefcontext_bad_fields \
+	"${FIXTURES}/file_contexts/bad_fields.mod.fc"
+
+expect_sefcontext_fail \
+	"NUL byte in .mod.fc path field (after packaging)" \
+	"missing fields|process_file failed" \
+	sefcontext_nul_bytes \
+	"${OUTDIR}/nul_bytes.mod.fc"
+
+expect_sefcontext_fail_or_skip_no_policy \
+	"invalid SELinux context requires policy validation (-p)" \
+	"invalid context|malformed context|process_file failed" \
+	sefcontext_bad_context \
+	"${FIXTURES}/file_contexts/bad_context.mod.fc"
+
+expect_sefcontext_pass_deferred \
+	"empty .mod.fc file through sefcontext_compile" \
+	sefcontext_empty_fc \
+	"${OUTDIR}/empty.mod.fc"
+
+expect_sefcontext_fail_or_skip_no_policy \
+	"invalid MLS context requires policy validation (-p)" \
+	"invalid context|malformed context|process_file failed" \
+	sefcontext_bad_mls \
+	"${FIXTURES}/file_contexts/bad_mls.mod.fc"
+
+BAD_PP="${OUTDIR}/bad_context.pp"
+EXTRACTED_MOD="${OUTDIR}/extracted.mod"
+EXTRACTED_FC="${OUTDIR}/extracted.fc"
+
+echo "==== Setup: extract file contexts from packaged module with invalid context"
+rm -f "${EXTRACTED_MOD}" "${EXTRACTED_FC}"
+set +e
+"${SEMODULE_UNPACKAGE}" "${BAD_PP}" "${EXTRACTED_MOD}" "${EXTRACTED_FC}" \
+	2>"${OUTDIR}/unpackage.err"
+rc=$?
+set -e
+if [ "${rc}" -ne 0 ] || [ ! -s "${EXTRACTED_FC}" ]; then
+	die "unpackage setup: could not extract .fc from ${BAD_PP}"
+	cat "${OUTDIR}/unpackage.err" >&2
+else
+	echo "==== unpackage setup succeeded"
+	echo ""
+	expect_sefcontext_fail_or_skip_no_policy \
+		"invalid context from unpackage'd .pp file contexts" \
+		"invalid context|malformed context|process_file failed" \
+		unpackaged_bad_context \
+		"${EXTRACTED_FC}"
+fi
 
 echo "========================================"
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
## Summary

This PR extends the `semodule-utils` bad-data harness with tests for `sefcontext_compile` and `semodule_unpackage` — the labeling validation stage after `semodule_package`.

The tests verify that malformed `.mod.fc` content is caught by `sefcontext_compile`, invalid contexts and invalid MLS ranges are rejected with a binary policy (`-p`), empty `.mod.fc` compile behavior is documented (completing the packaging deferral chain), and invalid contexts embedded in a packaged `.pp` are rejected when extracted and compiled.

Builds on [PR #82](https://github.com/fedora-selinux/selinux/pull/82) (Bucket C `semodule_package` tests). The shared harness runs both packaging and labeling stages in one driver.

## What this tests

The harness (`semodule-utils/tests/bad-data/run.sh`) exercises the post-packaging labeling path:

```
.mod.fc ──semodule_package──► .pp ──semodule_unpackage──► .fc
   │                                                              │
   └──────────── sefcontext_compile ──────────────────────────────┘
```

## How to run locally

```bash
make -C semodule-utils test
```

Requires `checkmodule`, `semodule_package`, `sefcontext_compile`, and `semodule_unpackage` on `PATH`.

Expected: **23 passed, 0 failed**

Unreadable `-m`/`-f` tests skip when run as root. Policy-dependent labeling tests (`-p`) skip when no binary policy is available (`POLICY_FILE` or `/etc/selinux/targeted/policy/policy.*`).

## Test results

### Local execution

- **Command:** `cd semodule-utils && make test`
- **Result:** 19 passed, 0 failed (exit 0)

### Results by test case

| Area | Input | Expected behavior |
|------|-------|-------------------|
| Control | Good `.mod.fc` | `sefcontext_compile` succeeds |
| Format errors | Wrong field count, NUL in path | Rejected (rc=255) |
| Policy validation | Invalid context, invalid MLS range | Rejected with `-p` (or SKIP if no binary policy) |
| Unpackage round-trip | Invalid context from packaged `.pp` | Rejected with `-p` (or SKIP if no binary policy) |
| Empty file (document) | Empty `.mod.fc` after packaging accepted it | `sefcontext_compile` succeeds (deferred enforcement documented) |

**7 new labeling test cases** — 1 control + 4 enforcement (2 structural + 2 policy-dependent that may SKIP) + 1 DOC-ONLY + 1 unpackage policy test. Full harness: **23 tests** (16 packaging from #82 + 7 labeling).

## What changed
- `semodule-utils/tests/bad-data/run.sh` — add `sefcontext_compile` / `semodule_unpackage` helpers and 7 labeling test cases (extends Bucket C driver from #82)
- `semodule-utils/tests/bad-data/fixtures/file_contexts/bad_mls.mod.fc` — invalid MLS category fixture

Inherited from #82 (not new in this PR): `Makefile`, `good.te`, `good.mod.fc`, `bad_context.mod.fc`, `bad_fields.mod.fc`, packaging tests, non-root CI in `run_tests.yml`.

<details>
<summary>Full local output</summary>

<pre>
==== Setup: build control module /tmp/semodule-package-bad-data.XXXXXX/test_good.mod from good.te

==== POSITIVE (expect semodule_package success): control good .mod without file contexts
==== control good .mod without file contexts (exit 0, .pp created)

==== POSITIVE (expect semodule_package success): control good .mod with good .mod.fc
==== control good .mod with good .mod.fc (exit 0, .pp created)

==== NEGATIVE (expect semodule_package failure): missing -m path
==== missing -m path (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): missing -f path
==== missing -f path (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): directory instead of -m file
==== directory instead of -m file (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): broken symlink for -m
==== broken symlink for -m (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): unreadable -m file
==== unreadable -m file (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): empty -m path argument
==== empty -m path argument (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): directory instead of -f file
==== directory instead of -f file (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): broken symlink for -f
==== broken symlink for -f (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): unreadable -f file
==== unreadable -f file (rejected as expected, rc=1)

==== NEGATIVE (expect semodule_package failure): empty -f path argument
==== empty -f path argument (rejected as expected, rc=1)

==== DOCUMENT (semodule_package accepts input; validate in sefcontext_compile): invalid SELinux context in .mod.fc
==== invalid SELinux context in .mod.fc (packaging exit 0; labeling validation deferred to sefcontext_compile)

==== DOCUMENT (semodule_package accepts input; validate in sefcontext_compile): wrong field count in .mod.fc
==== wrong field count in .mod.fc (packaging exit 0; labeling validation deferred to sefcontext_compile)

==== DOCUMENT (semodule_package accepts input; validate in sefcontext_compile): NUL byte in .mod.fc path field
==== NUL byte in .mod.fc path field (packaging exit 0; labeling validation deferred to sefcontext_compile)

==== DOCUMENT (semodule_package accepts input; validate in sefcontext_compile): empty .mod.fc file
==== empty .mod.fc file (packaging exit 0; labeling validation deferred to sefcontext_compile)

==== POSITIVE (expect sefcontext_compile success): control good .mod.fc through sefcontext_compile
==== control good .mod.fc through sefcontext_compile (sefcontext_compile succeeded)

==== NEGATIVE (expect sefcontext_compile failure): wrong field count in .mod.fc (after packaging)
==== wrong field count in .mod.fc (after packaging) (rejected as expected, rc=255)

==== NEGATIVE (expect sefcontext_compile failure): NUL byte in .mod.fc path field (after packaging)
==== NUL byte in .mod.fc path field (after packaging) (rejected as expected, rc=255)

==== NEGATIVE (expect sefcontext_compile failure): invalid SELinux context requires policy validation (-p)
==== invalid SELinux context requires policy validation (-p) (rejected as expected, rc=255)

==== DOCUMENT (sefcontext_compile accepts input; complements packaging deferral): empty .mod.fc file through sefcontext_compile
==== empty .mod.fc file through sefcontext_compile (sefcontext_compile exit 0; complements packaging deferral)

==== NEGATIVE (expect sefcontext_compile failure): invalid MLS context requires policy validation (-p)
==== invalid MLS context requires policy validation (-p) (rejected as expected, rc=255)

==== Setup: extract file contexts from packaged module with invalid context
==== unpackage setup succeeded

==== NEGATIVE (expect sefcontext_compile failure): invalid context from unpackage'd .pp file contexts
==== invalid context from unpackage'd .pp file contexts (rejected as expected, rc=255)

========================================
Results: 23 passed, 0 failed

</pre>

</details>