### PR TITLE
sepolicy: Fix detection of writeable locations

### DIFF
--- a/python/sepolicy/sepolicy/generate.py
+++ b/python/sepolicy/sepolicy/generate.py
@@ -1267,15 +1267,15 @@ allow %s_t %s_t:%s_socket name_%s;
         import dnf
 
         with dnf.Base() as base:
+            base.conf.substitutions.update_from_etc('/')
             base.read_all_repos()
             base.fill_sack(load_system_repo=True)
 
             query = base.sack.query()
 
-            pq = query.available()
-            pq = pq.filter(file=self.program)
+            pq = query.filter(file=self.program)
 
-            for pkg in pq:
+            for pkg in pq.run():
                 self.rpms.append(pkg.name)
                 for fname in pkg.files:
                     for b in self.DEFAULT_DIRS:
@@ -1288,7 +1288,7 @@ allow %s_t %s_t:%s_socket name_%s;
                                 self.add_dir(fname)
                 sq = query.available()
                 sq = sq.filter(provides=pkg.source_name)
-                for bpkg in sq:
+                for bpkg in sq.run():
                     for fname in bpkg.files:
                         for b in self.DEFAULT_DIRS:
                             if b == "/etc":


### PR DESCRIPTION
- update substitutions from /etc/dnf/var

It seems that by default dnf api does not read /etc/dnf/var/* files to update substitutions and so it can't resolve correct mirror list when a variable is part of the link.

- alway run query.run()

Fixes:
    Traceback (most recent call last):
      File "/usr/lib/python3.12/site-packages/dnf/repo.py", line 574, in load
        ret = self._repo.load()
              ^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/site-packages/libdnf/repo.py", line 467, in load
        return _repo.Repo_load(self)
               ^^^^^^^^^^^^^^^^^^^^^
    libdnf._error.Error: Failed to download metadata for repo 'baseos':
    Cannot prepare internal mirrorlist: Status code: 404 for
    https://mirrors.centos.org/metalink?repo=centos-baseos-$stream&arch=x86_64&protocol=https,http (IP:152.19.134.198)

Please read [CONTRIBUTING.md](https://github.com/SELinuxProject/selinux/blob/main/CONTRIBUTING.md)

## Contributing Code

Post the patch for the review to the
[SELinux mailing list](https://lore.kernel.org/selinux) at
[selinux@vger.kernel.org](mailto:selinux@vger.kernel.org).

When preparing patches, please follow these guidelines:

-   Patches should apply with git am
-   Must apply against HEAD of the main branch
-   Separate large patches into logical patches
-   Patch descriptions must end with your "Signed-off-by" line. This means your
    code meets the Developer's certificate of origin, see below.
