### PR TITLE
libsemanage/genhomedircon: reject users with a relative home directory

### DIFF
--- a/libsemanage/src/genhomedircon.c
+++ b/libsemanage/src/genhomedircon.c
@@ -1110,6 +1110,17 @@ retry:
 		pwent->pw_dir[len] = '\0';
 	}
 
+	if (pwent->pw_dir[0] != '/') {
+		/* an empty (or otherwise relative) home directory would
+		 * turn the HOME_DIR template into a regex that matches
+		 * everything, e.g. "/.+", so refuse to use it */
+		WARN(s->h_semanage,
+		     "user %s has an invalid home directory \"%s\", ignoring",
+		     name, pwent->pw_dir);
+		retval = STATUS_SUCCESS;
+		goto cleanup;
+	}
+
 	if (strcmp(pwent->pw_dir, "/") == 0) {
 		/* don't relabel / genhomdircon checked to see if root
 		 * was the user and if so, set his home directory to


### PR DESCRIPTION
If a user's home directory in the password database is empty or otherwise does not start with "/" (e.g. because of a broken NSS lookup or a malformed passwd entry), the HOME_DIR template ends up being turned into a regular expression such as "/.+", which matches any path on the filesystem. This causes genhomedircon to generate a file context that relabels far more of the filesystem than intended. Skip such users instead of using their home directory to build the regex.


Acked-by: Stephen Smalley <stephen.smalley.work@gmail.com>

Please read [CONTRIBUTING.md](https://github.com/SELinuxProject/selinux/blob/main/CONTRIBUTING.md)

## Contributing Code

Post the patch for the review to the
[SELinux mailing list](https://lore.kernel.org/selinux) at
[selinux@vger.kernel.org](mailto:selinux@vger.kernel.org).

When preparing patches, please follow these guidelines:

-   Patches should apply with git am
-   Must apply against HEAD of the main branch
-   Separate large patches into logical patches
-   Patch descriptions must end with your "Signed-off-by" line. This means your
    code meets the Developer's certificate of origin, see below.
